### PR TITLE
Allow using maps instead of structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ import (
 	"github.com/resin-io/pinejs-client-go/resin"
 )
 
+// Using a struct
 func GetDatDevice() {
 	var device resin.Device{Id: 1234}
 	pineClient := pinejs.NewClient("https://api.resinstaging.io/ewa", "secretapikey")
@@ -21,7 +22,21 @@ func GetDatDevice() {
 		// device contains the device object with id 1234.
 	}
 }
+
+// Using a map
+func GetDatDeviceOnAMap() {
+	device := map[string]interface{}{"pinejs": "device", "id": 1234}
+	pineClient := pinejs.NewClient("https://api.resinstaging.io/ewa", "secretapikey")
+
+	if err := pineClient.Get(&device); err != nil {
+		log.Fatalln(err)
+	} else {
+		// device contains the device object with id 1234.
+	}
+}
 ```
+
+More examples in [test/test.go](./test/test.go)
 
 [pine]:https://bitbucket.org/rulemotion/pinejs/overview
 [resin]:https://resin.io

--- a/pinejs.go
+++ b/pinejs.go
@@ -62,12 +62,15 @@ func NewClient(endpoint, apiKey string) *Client {
 // it into the provided v interface. Optionally, query options can be set on the
 // data.
 //
-// Get expects v to be a pointer to a struct, and there to be an Id field set to
-// a valid id (i.e. non-zero.)
+// Get expects v to either one of:
+//   * a pointer to a struct, and there to be an Id field set to
+//     a valid id (i.e. non-zero.)
+//   * a pointer to a map[string]interface{}, with a "pinejs" field set to the
+//     resource name and an "id" field set to a non-zero integer
 //
-// Get determines the name of resource to retrieve from a pinejs tag placed on
-// any field in the struct, or if this is not present, the struct name in lower
-// case.
+// If v is a struct, get determines the name of resource to retrieve from a pinejs
+// tag placed on any field in the struct, or if this is not present, the struct name
+// in lower case.
 //
 // Data is decoded using the standard library's encoding/json package, so ensure
 // to export all fields you wish to decode to and set json tags as appropriate.
@@ -80,7 +83,7 @@ func NewClient(endpoint, apiKey string) *Client {
 // the library will simply set the Id field and expect you to manually request
 // the rest of the struct's data.
 func (c *Client) Get(v interface{}, queryOptions ...QueryOption) error {
-	if _, err := isPointerToStruct(v); err != nil {
+	if _, err := isPointerToStructOrMap(v); err != nil {
 		return err
 	}
 
@@ -102,11 +105,12 @@ func (c *Client) Get(v interface{}, queryOptions ...QueryOption) error {
 // List returns all elements of a specific resource according to the query
 // options specified, if any.
 //
-// List expects v to be a pointer to a slice of structs.
+// List expects v to be a pointer to a slice of structs or maps.
+// In the map case, the first element of the slice must exist and have a "pinejs" field with the resource name.
 //
 // See Get for further details.
 func (c *Client) List(v interface{}, queryOptions ...QueryOption) error {
-	if _, err := isPointerToSliceStructs(v); err != nil {
+	if _, err := isPointerToSliceStructsOrMaps(v); err != nil {
 		return err
 	} else if name, err := resourceName(v); err != nil {
 		return err
@@ -118,23 +122,23 @@ func (c *Client) List(v interface{}, queryOptions ...QueryOption) error {
 }
 
 // Read choose to Get or List depending on the type of v - Get if v is a pointer
-// to a struct, List if v is a pointer to a slice.
+// to a struct or map, List if v is a pointer to a slice.
 //
 // See Get and List for further details.
 func (c *Client) Read(v interface{}, queryOptions ...QueryOption) error {
-	if isSlice, _ := isPointerToSliceStructs(v); isSlice {
+	if isSlice, _ := isPointerToSliceStructsOrMaps(v); isSlice {
 		return c.List(v, queryOptions...)
-	} else if isStruct, _ := isPointerToStruct(v); isStruct {
+	} else if isStructOrMap, _ := isPointerToStructOrMap(v); isStructOrMap {
 		return c.Get(v, queryOptions...)
 	}
 
-	return errors.New("not a pointer to a struct or slice")
+	return errors.New("not a pointer to a struct, map or slice")
 }
 
 // Create generates a new entity of a specific resource, and populates fields as
 // they are in the database, including Id.
 //
-// Create expects v to be a pointer to a struct.
+// Create expects v to be a pointer to a struct or map.
 //
 // See Get for further details.
 func (c *Client) Create(v interface{}, queryOptions ...QueryOption) error {
@@ -216,7 +220,8 @@ func (c *Client) Patch(v interface{}) error {
 
 // Deletes deletes a specific resource's entity given a specific id.
 //
-// Delete expects v to be a pointer to a struct, and there to be an Id field set to
+// Delete expects v to be a pointer to a struct or map, and there to be an Id field
+// (in the struct case) or "id" element (in the map case) set to
 // a valid id (i.e. non-zero.)
 //
 // See Get for further details.

--- a/pinejs.go
+++ b/pinejs.go
@@ -138,7 +138,7 @@ func (c *Client) Read(v interface{}, queryOptions ...QueryOption) error {
 //
 // See Get for further details.
 func (c *Client) Create(v interface{}, queryOptions ...QueryOption) error {
-	if _, err := isPointerToStruct(v); err != nil {
+	if _, err := isPointerToStructOrMap(v); err != nil {
 		return err
 	}
 
@@ -161,12 +161,13 @@ func (c *Client) Create(v interface{}, queryOptions ...QueryOption) error {
 // are overwritten. If an entity with the specific id doesn't already exist, it
 // is created.
 //
-// Update expects v to be a pointer to a struct, and there to be an Id field set to
+// Update expects v to be a pointer to a struct or map, and there to be an Id field
+// (in the struct case) or "id" element (in the map case) set to
 // a valid id (i.e. non-zero.)
 //
 // See Get for further details.
 func (c *Client) Update(v interface{}) error {
-	if _, err := isPointerToStruct(v); err != nil {
+	if _, err := isPointerToStructOrMap(v); err != nil {
 		return err
 	}
 
@@ -188,12 +189,13 @@ func (c *Client) Update(v interface{}) error {
 // Patch updates a specific resource's entity given a specific id, updating only
 // the specified fields.
 //
-// Patch expects v to be a pointer to a struct, and there to be an Id field set to
+// Patch expects v to be a pointer to a struct or map, and there to be an Id field
+// (in the struct case) or "id" element (in the map case) set to
 // a valid id (i.e. non-zero.)
 //
 // See Get for further details.
 func (c *Client) Patch(v interface{}) error {
-	if _, err := isPointerToStruct(v); err != nil {
+	if _, err := isPointerToStructOrMap(v); err != nil {
 		return err
 	}
 
@@ -219,7 +221,7 @@ func (c *Client) Patch(v interface{}) error {
 //
 // See Get for further details.
 func (c *Client) Delete(v interface{}) error {
-	if _, err := isPointerToStruct(v); err != nil {
+	if _, err := isPointerToStructOrMap(v); err != nil {
 		return err
 	}
 

--- a/test/test.go
+++ b/test/test.go
@@ -31,11 +31,28 @@ func main() {
 		fmt.Printf("Got apps: %+v\n", userApps)
 	}
 
+	userAppMaps := make([]map[string]interface{}, 1)
+	userAppMaps[0] = make(map[string]interface{})
+	userAppMaps[0]["pinejs"] = "application"
+	fmt.Println("Getting all apps with a slice of maps")
+	err = resinApi.List(&userAppMaps)
+
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Printf("Got apps: %+v\n", userAppMaps)
+	}
+
 	fmt.Println("Getting one Application")
 
 	resinApi.Get(&myApp)
 
 	fmt.Printf("%+v\n", myApp)
+
+	fmt.Println("Getting one Application with a map")
+	appMap := map[string]interface{}{"pinejs": "application", "id": appId}
+	resinApi.Get(&appMap)
+	fmt.Printf("%+v\n", appMap)
 
 	fmt.Println("Creating a device")
 	dev := make(map[string]interface{})

--- a/test/test.go
+++ b/test/test.go
@@ -2,36 +2,55 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 
-	"pinejs-client-go"
-	"pinejs-client-go/resin"
+	"github.com/resin-io/pinejs-client-go"
+	"github.com/resin-io/pinejs-client-go/resin"
 )
 
 func main() {
 	resinApi := &pinejs.Client{
-		Endpoint: "https://alpha.resin.io/ewa",
-		APIKey:   "bananasbananas",
+		Endpoint: os.Getenv("API_ENDPOINT"),
+		APIKey:   os.Getenv("API_KEY"),
 	}
 
-	// var userApps []resin.Application
-	myApp := resin.Application{Id: 338}
+	var userApps []resin.Application
+	var err error
+	appId, _ := strconv.Atoi(os.Getenv("APP_ID"))
+	userId, _ := strconv.Atoi(os.Getenv("USER_ID"))
 
-	resinApi.List(&userApps)
+	myApp := resin.Application{Id: appId}
 
-	// if err != nil {
-	// 	fmt.Println(err)
-	// }
+	fmt.Println("Getting all apps")
+	err = resinApi.List(&userApps)
 
-	// for _, app := range userApps {
-	// 	fmt.Println(app.AppName)
-	// 	for _, device := range app.Devices {
-	// 		fmt.Println("-->", device)
-	// 	}
-	// }
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Printf("Got apps: %+v\n", userApps)
+	}
 
 	fmt.Println("Getting one Application")
 
 	resinApi.Get(&myApp)
 
-	fmt.Println(myApp)
+	fmt.Printf("%+v\n", myApp)
+
+	fmt.Println("Creating a device")
+	dev := make(map[string]interface{})
+
+	dev["pinejs"] = "device"
+	dev["uuid"] = os.Getenv("TEST_UUID")
+	dev["device_type"] = "raspberry-pi2"
+	dev["application"] = appId
+	dev["user"] = userId
+	fmt.Printf("%+v", dev)
+
+	err = resinApi.Create(&dev)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Printf("Created device: %v", dev)
+	}
 }

--- a/util.go
+++ b/util.go
@@ -85,13 +85,13 @@ func isPointerToStructOrMap(v interface{}) (bool, error) {
 	return true, nil
 }
 
-func isPointerToSliceStructs(v interface{}) (bool, error) {
+func isPointerToSliceStructsOrMaps(v interface{}) (bool, error) {
 	if el, err := ptrType(v); err != nil {
 		return false, err
 	} else if el.Kind() != reflect.Slice {
 		return false, errors.New("not a pointer to a slice")
-	} else if el.Elem().Kind() != reflect.Struct {
-		return false, errors.New("not a pointer to a slice of structs")
+	} else if el.Elem().Kind() != reflect.Struct && el.Elem().Kind() != reflect.Map {
+		return false, errors.New("not a pointer to a slice of structs or maps")
 	}
 
 	return true, nil

--- a/util.go
+++ b/util.go
@@ -75,6 +75,16 @@ func isPointerToStruct(v interface{}) (bool, error) {
 	return true, nil
 }
 
+func isPointerToStructOrMap(v interface{}) (bool, error) {
+	if el, err := ptrType(v); err != nil {
+		return false, err
+	} else if el.Kind() != reflect.Struct && el.Kind() != reflect.Map {
+		return false, errors.New("not a pointer to a struct or map")
+	}
+
+	return true, nil
+}
+
 func isPointerToSliceStructs(v interface{}) (bool, error) {
 	if el, err := ptrType(v); err != nil {
 		return false, err
@@ -158,32 +168,4 @@ func getJsonArray(j *simplejson.Json) (ret []*simplejson.Json, err error) {
 	}
 
 	return
-}
-
-// Determine whether the struct's id will be omitted in json encoding.
-func isIdOmitted(v interface{}) (bool, error) {
-	if f, err := getResourceField(v); err != nil {
-		return false, err
-	} else if jsonTag := f.Tag("json"); jsonTag == "" {
-		// No json tag means the id field won't be ommitted.
-		return false, nil
-	} else {
-		// getResourceField() ensures this is an int.
-		id := f.Value().(int)
-
-		// Json tags are comma separated. 'omitempty' means id == 0 -> id field
-		// not included in generated json. Also note spacing, like "id,
-		// omitempty" is significant and prevents a tag from taking effect so no
-		// need for trimming.
-		//
-		// See http://golang.org/pkg/encoding/json/#Marshal
-		for _, field := range strings.Split(jsonTag, ",") {
-			if field == "omitempty" && id == 0 {
-				return true, nil
-			}
-		}
-	}
-
-	// Id field exists, no 'omitempty' tag so not omitted.
-	return false, nil
 }


### PR DESCRIPTION
Sometimes we want to deal with objects with dynamic fields, especially in resin-supervisor where we only want to set certain fields, and sometimes we want to set fields as null.

Adding omitempty to some fields in the resin models would allow us to not send certain fields, but would not allow to send them as null values.
Conversely, changing fields in the resin models to pointers would allow us to send fields as null, but would not allow us to not send certain fields at all.

By allowing users of this library to pass the request objects as a `map[string]interface{}`, we give the flexibility to either not include a field (by not adding the key to the map) or to send it as null (by setting the value of that key to `nil`.

We add this option to all the REST methods, which gives users the possibility to use this library only with maps, and without knowledge of all the fields in the resin models.